### PR TITLE
QAT bug fix to return same results as quantize.py

### DIFF
--- a/ai8x.py
+++ b/ai8x.py
@@ -29,7 +29,7 @@ class normalize:
     def __call__(self, img):
         if self.args.act_mode_8bit:
             return img.sub(0.5).mul(256.).round().clamp(min=-128, max=127)
-        return img.sub(0.5)
+        return img.sub(0.5).mul(256.).round().clamp(min=-128, max=127).div(256.)
 
 
 class QuantizationFunction(Function):


### PR DESCRIPTION
- QAT trained models now give the same results with their quantize.py'ed versions. For solving the issue, there are changes both in the training and synthesis repos.